### PR TITLE
[Feat] 회원가입 및 리프레시 토큰으로 액세스 토큰 발급

### DIFF
--- a/src/main/java/org/routemaster/api/auth/domain/user/email/impl/data/EmailUser.java
+++ b/src/main/java/org/routemaster/api/auth/domain/user/email/impl/data/EmailUser.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.*;
 import org.routemaster.api.auth.domain.user.impl.data.DefaultUserDetails;
 import org.routemaster.api.auth.domain.user.impl.util.constant.UserTime;
@@ -53,13 +54,18 @@ public class EmailUser implements DefaultUserDetails, Serializable {
     @Field(name = "refresh_token")
     private String refreshToken;
 
+    public EmailUser ready(EmailUserReady ready) {
+        this.authorities = ready.getAuthorities();
+        this.password = ready.getPassword();
+        return this;
+    }
+
     @JsonIgnore
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        LocalDateTime.now();
-        return authorities.stream()
+        return Objects.nonNull(authorities) ? authorities.stream()
                 .map(authority -> new SimpleGrantedAuthority(authority))
-                .collect(Collectors.toSet());
+                .collect(Collectors.toSet()) : null;
     }
 
     @JsonProperty("authorities")

--- a/src/main/java/org/routemaster/api/auth/domain/user/email/impl/service/EmailUserService.java
+++ b/src/main/java/org/routemaster/api/auth/domain/user/email/impl/service/EmailUserService.java
@@ -4,6 +4,8 @@ import org.routemaster.api.auth.domain.user.email.impl.data.EmailUser;
 
 public interface EmailUserService {
 
+    EmailUser register(String username, String password);
+
     EmailUser verifyRegister(String username, String verificationCode);
     EmailUser updatePassword(String username, String password);
     EmailUser updateRefreshToken(String username, String refreshToken);

--- a/src/main/java/org/routemaster/api/auth/domain/user/email/impl/service/impl/DefaultEmailUserReadyService.java
+++ b/src/main/java/org/routemaster/api/auth/domain/user/email/impl/service/impl/DefaultEmailUserReadyService.java
@@ -37,13 +37,6 @@ public class DefaultEmailUserReadyService implements EmailUserReadyService {
     public EmailUserReady register(EmailUserReady user) {
         String username = user.getUsername();
 
-        if (emailUserRepository.existsByUsername(username)) {
-            throw roeFactory.get(
-                UserErrorCode.ROE_100,
-                EmailUserErrorDescription.EMAIL_USER_ALREADY_EXIST,
-                HttpStatus.BAD_REQUEST);
-        }
-
         Optional<EmailUserReady> prev = emailUserReadyRepository.findByUsername(username);
         EmailUserReady basicUserReady = prev.isEmpty() ? emailUserReadyMapper.register(user)
             : emailUserReadyMapper.register(prev.get(), user);

--- a/src/main/java/org/routemaster/api/auth/domain/user/email/impl/util/mapper/EmailUserMapper.java
+++ b/src/main/java/org/routemaster/api/auth/domain/user/email/impl/util/mapper/EmailUserMapper.java
@@ -5,12 +5,16 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.routemaster.api.auth.domain.user.email.impl.data.EmailUser;
 import org.routemaster.api.auth.domain.user.email.impl.data.EmailUserReady;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class EmailUserMapper {
+
+    private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
     public EmailUser register(EmailUserReady emailUserReady) {
         return EmailUser.builder()
@@ -20,6 +24,35 @@ public class EmailUserMapper {
             .createdAt(LocalDateTime.now())
             .updatedAt(null)
             .passwordUpdatedAt(emailUserReady.getCreatedAt())
+            .lastActiveTime(LocalDateTime.now())
+            .lockExpiredAt(null)
+            .refreshToken(null)
+            .build();
+    }
+
+    public EmailUser register(String username, String password) {
+        return EmailUser.builder()
+            .username(username)
+            .password(passwordEncoder.encode(password))
+            .authorities(null)
+            .createdAt(LocalDateTime.now())
+            .updatedAt(null)
+            .passwordUpdatedAt(LocalDateTime.now())
+            .lastActiveTime(LocalDateTime.now())
+            .lockExpiredAt(null)
+            .refreshToken(null)
+            .build();
+    }
+
+    public EmailUser register(String id, String username, String password) {
+        return EmailUser.builder()
+            .id(id)
+            .username(username)
+            .password(passwordEncoder.encode(password))
+            .authorities(null)
+            .createdAt(LocalDateTime.now())
+            .updatedAt(null)
+            .passwordUpdatedAt(LocalDateTime.now())
             .lastActiveTime(LocalDateTime.now())
             .lockExpiredAt(null)
             .refreshToken(null)

--- a/src/main/java/org/routemaster/api/auth/domain/user/impl/service/impl/DefaultBaseUserService.java
+++ b/src/main/java/org/routemaster/api/auth/domain/user/impl/service/impl/DefaultBaseUserService.java
@@ -63,7 +63,11 @@ public class DefaultBaseUserService implements BaseUserService {
     @Override
     @Transactional
     public BaseUser save(UserType type, String id) {
-        return save(baseUserMapper.register(type, id));
+        try {
+            return details(type, id);
+        } catch (Exception e) {
+            return save(baseUserMapper.register(type, id));
+        }
     }
 
     @Override

--- a/src/main/java/org/routemaster/api/auth/domain/user/jwt/impl/data/UserJwtPayload.java
+++ b/src/main/java/org/routemaster/api/auth/domain/user/jwt/impl/data/UserJwtPayload.java
@@ -9,8 +9,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.routemaster.api.auth.domain.user.email.impl.data.EmailUser;
+import org.routemaster.api.auth.domain.user.impl.data.BaseUser;
 import org.routemaster.api.auth.domain.user.impl.util.constant.UserType;
 import org.routemaster.api.auth.domain.user.jwt.impl.utils.constant.JwtType;
+import org.routemaster.api.auth.domain.user.social.impl.data.SocialUser;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.PortResolverImpl;
 
@@ -25,4 +28,24 @@ public class UserJwtPayload {
     private Set<String> authorities;
     private UserType userType;
     private JwtType jwtType;
+
+    public static UserJwtPayload of(EmailUser user, BaseUser baseUser) {
+        return UserJwtPayload.builder()
+            .baseUserId(baseUser.getId())
+            .typeUserId(user.getId())
+            .authorities(user.getStringAuthorities())
+            .userType(user.getType())
+            .jwtType(JwtType.ACCESS_TOKEN)
+            .build();
+    }
+
+    public static UserJwtPayload of(SocialUser user, BaseUser baseUser) {
+        return UserJwtPayload.builder()
+            .baseUserId(baseUser.getId())
+            .typeUserId(user.getId())
+            .authorities(user.getStringAuthorities())
+            .userType(user.getType())
+            .jwtType(JwtType.ACCESS_TOKEN)
+            .build();
+    }
 }

--- a/src/main/java/org/routemaster/api/auth/domain/user/social/impl/service/impl/DefaultSocialUserService.java
+++ b/src/main/java/org/routemaster/api/auth/domain/user/social/impl/service/impl/DefaultSocialUserService.java
@@ -51,7 +51,7 @@ public class DefaultSocialUserService implements SocialUserService {
             throw roeFactory.get(
                 UserErrorCode.ROE_100,
                 SocialUserErrorDescription.SOCIAL_USER_ALREADY_EXIST,
-                HttpStatus.BAD_REQUEST
+                HttpStatus.CONFLICT
             );
         }
         SocialUser socialUser = socialUserMapper.register(provider, socialId, authorities);

--- a/src/main/java/org/routemaster/api/auth/endpoint/user/email/impl/util/mapper/EndpointEmailUserReadyMapper.java
+++ b/src/main/java/org/routemaster/api/auth/endpoint/user/email/impl/util/mapper/EndpointEmailUserReadyMapper.java
@@ -1,8 +1,10 @@
 package org.routemaster.api.auth.endpoint.user.email.impl.util.mapper;
 
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.routemaster.api.auth.domain.user.email.impl.data.EmailUserReady;
+import org.routemaster.api.auth.domain.user.impl.util.constant.UserRole;
 import org.routemaster.api.auth.endpoint.user.email.impl.vo.request.EmailUserRegisterRequest;
 import org.springframework.stereotype.Component;
 
@@ -15,7 +17,7 @@ public class EndpointEmailUserReadyMapper {
         return EmailUserReady.builder()
             .username(request.getUsername())
             .password(request.getPassword())
-            .authorities(request.getAuthorities())
+            .authorities(Set.of(UserRole.ROLE_USER))
             .build();
     }
 }

--- a/src/main/java/org/routemaster/api/auth/endpoint/user/email/impl/vo/request/EmailUserRegisterRequest.java
+++ b/src/main/java/org/routemaster/api/auth/endpoint/user/email/impl/vo/request/EmailUserRegisterRequest.java
@@ -3,12 +3,16 @@ package org.routemaster.api.auth.endpoint.user.email.impl.vo.request;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.util.List;
 import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
+import org.routemaster.api.auth.endpoint.user.info.privacy.impl.vo.request.UserPrivacySaveAllRequest;
+import org.routemaster.api.auth.endpoint.user.info.privacy.impl.vo.request.UserPrivacySaveRequest;
+import org.routemaster.api.auth.endpoint.user.info.profile.impl.vo.request.UserProfileTotalSaveRequest;
 import org.routemaster.api.auth.global.util.validation.constraints.Password;
 
 @NoArgsConstructor
@@ -22,8 +26,8 @@ public class EmailUserRegisterRequest {
     @Password
     private String password;
 
-    // "ROLE_USER"
     @NotNull
-    @Size(min = 1, max = 5)
-    private Set<@Length(min = 1, max = 32) String> authorities;
+    private UserPrivacySaveAllRequest privacy;
+    @NotNull
+    private UserProfileTotalSaveRequest profile;
 }

--- a/src/main/java/org/routemaster/api/auth/endpoint/user/impl/controller/UserRestController.java
+++ b/src/main/java/org/routemaster/api/auth/endpoint/user/impl/controller/UserRestController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.routemaster.api.auth.domain.user.impl.data.DefaultUserDetails;
 import org.routemaster.api.auth.domain.user.jwt.impl.data.UserJwtPayload;
+import org.routemaster.api.auth.domain.user.jwt.impl.data.UserJwtUnit;
 import org.routemaster.api.auth.domain.user.jwt.impl.utils.filter.UserJwtAuthenticationFilter;
 import org.routemaster.api.auth.endpoint.user.impl.service.ClientUserEndpointService;
 import org.routemaster.api.auth.endpoint.user.impl.service.UserEndpointService;
@@ -43,10 +44,19 @@ public class UserRestController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
+    @PatchMapping("/refresh")
+    @SecurityRequirement(name = "Bearer Authentication")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    public ResponseEntity<UserJwtUnit> refresh(
+        @RequestAttribute(UserJwtAuthenticationFilter.USER_PAYLOAD) UserJwtPayload payload) {
+        UserJwtUnit unit = userEndpointService.refresh(payload);
+        return new ResponseEntity<>(unit, HttpStatus.OK);
+    }
+
     @DeleteMapping
     @SecurityRequirement(name = "Bearer Authentication")
     @PreAuthorize("hasRole('ROLE_USER')")
-    public ResponseEntity<Void> delete(
+    public ResponseEntity<UserJwtUnit> delete(
         @RequestAttribute(UserJwtAuthenticationFilter.USER_PAYLOAD) UserJwtPayload payload) {
         userEndpointService.delete(payload);
         return new ResponseEntity<>(null, HttpStatus.OK);

--- a/src/main/java/org/routemaster/api/auth/endpoint/user/impl/service/UserEndpointService.java
+++ b/src/main/java/org/routemaster/api/auth/endpoint/user/impl/service/UserEndpointService.java
@@ -1,9 +1,11 @@
 package org.routemaster.api.auth.endpoint.user.impl.service;
 
 import org.routemaster.api.auth.domain.user.jwt.impl.data.UserJwtPayload;
+import org.routemaster.api.auth.domain.user.jwt.impl.data.UserJwtUnit;
 
 public interface UserEndpointService {
 
     void logout(UserJwtPayload payload);
     void delete(UserJwtPayload payload);
+    UserJwtUnit refresh(UserJwtPayload payload);
 }

--- a/src/main/java/org/routemaster/api/auth/endpoint/user/social/vo/request/SocialUserRegisterRequest.java
+++ b/src/main/java/org/routemaster/api/auth/endpoint/user/social/vo/request/SocialUserRegisterRequest.java
@@ -1,10 +1,14 @@
 package org.routemaster.api.auth.endpoint.user.social.vo.request;
 
+import java.util.List;
 import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.routemaster.api.auth.endpoint.user.info.privacy.impl.vo.request.UserPrivacySaveAllRequest;
+import org.routemaster.api.auth.endpoint.user.info.privacy.impl.vo.request.UserPrivacySaveRequest;
+import org.routemaster.api.auth.endpoint.user.info.profile.impl.vo.request.UserProfileTotalSaveRequest;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -13,5 +17,6 @@ import lombok.NoArgsConstructor;
 public class SocialUserRegisterRequest {
 
     private String accessToken;
-    private Set<String> authorities;
+    private UserPrivacySaveAllRequest privacy;
+    private UserProfileTotalSaveRequest profile;
 }


### PR DESCRIPTION
# 회원가입 플로우 수정
- /email/register : 이메일, 비밀번호, 프로필, 이용 약관 동의 목록을 한꺼번에 받도록 수정
- /social/:provider/register : 액세스 토큰, 프로필, 이용 약관 동의 목록을 한꺼번에 받도록 수정
신규가입자 액세스 토큰 발급 플로우
이메일 유저 : /email/register -> /email/register/verification 으로 이메일로 온 검증 코드 전달 -> /email/login
소셜 유저 :  /social/:provider/register -> /social/:provider/login
